### PR TITLE
fix: adjust regex in ModelService to recognize o1- models returned from OpenAI-API query

### DIFF
--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -157,7 +157,7 @@ const fetchOpenAIModels = async (opts, _models = []) => {
   }
 
   if (baseURL === openaiBaseURL) {
-    const regex = /(text-davinci-003|gpt-)/;
+    const regex = /(text-davinci-003|gpt-|o1-)/;
     models = models.filter((model) => regex.test(model));
     const instructModels = models.filter((model) => model.includes('instruct'));
     const otherModels = models.filter((model) => !model.includes('instruct'));


### PR DESCRIPTION
## Summary

API query for OpenAI returns list of models. Their names are filtered using a regex. The regex did not yet account for model names starting with o1- - with this change, model names starting with "o1-" are also recognized and will be shown in UI.

closes https://github.com/danny-avila/LibreChat/issues/4339

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

performed `docker build` with this change and tested manually

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] A pull request for updating the documentation has been submitted.
